### PR TITLE
Upgrade to Pants 2.9 and demonstrate embedding and `testdata`

### DIFF
--- a/cmd/greeter_en/BUILD
+++ b/cmd/greeter_en/BUILD
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+go_package()
+
 # This target allows us to use `./pants run` and `./pants package` on this `main` Go package.
 #
 # You can optionally set the field `output_path="greeter_en"`, for example, for the binary's name

--- a/cmd/greeter_es/BUILD
+++ b/cmd/greeter_es/BUILD
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+go_package()
+
 # This target allows us to use `./pants run` and `./pants package` on this `main` Go package.
 #
 # You can optionally set the field `output_path="greeter_es"`, for example, for the binary's name

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.8.0"
+pants_version = "2.9.0.dev3"
 backend_packages = ["pants.backend.experimental.go"]
 
 [anonymous-telemetry]

--- a/pkg/embed_example/BUILD
+++ b/pkg/embed_example/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2021 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_package(dependencies=[":embeds", ":testdata"])
+
+resources(name="embeds", sources=["hello.txt"])
+files(name="testdata", sources=["testdata/*"])

--- a/pkg/embed_example/hello.txt
+++ b/pkg/embed_example/hello.txt
@@ -1,0 +1,1 @@
+I'm an embedded resource!

--- a/pkg/embed_example/lib.go
+++ b/pkg/embed_example/lib.go
@@ -1,0 +1,9 @@
+// Copyright 2021 Pants project contributors.
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package embed_example
+
+// TODO: enable after fixing Pants when lib code has embeds but tests don't.
+// import _ "embed"
+// //go:embed hello.txt
+// var embeddedHello string

--- a/pkg/embed_example/lib_test.go
+++ b/pkg/embed_example/lib_test.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Pants project contributors.
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package embed_example
+
+import (
+	"os"
+	"testing"
+)
+
+// TODO: enable after fixing Pants when lib code has embeds but tests don't.
+// func TestResourceEmbedding(t *testing.T) {
+//   if embeddedHello != "I'm an embedded resource!" {
+//     t.Fatalf("message mismatch: want=%s; got=%s", "I'm an embedded resource!", embeddedHello)
+//   }
+// }
+
+func TestTestDataFolder(t *testing.T) {
+	_, err := os.Stat("testdata/f.txt")
+	if err != nil {
+		t.Fatalf("Could not stat pkg/embed_example/testdata/f.txt: %v", err)
+	}
+}

--- a/pkg/embed_example/testdata/f.txt
+++ b/pkg/embed_example/testdata/f.txt
@@ -1,0 +1,1 @@
+Some test data!

--- a/pkg/greeter/BUILD
+++ b/pkg/greeter/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_package()

--- a/pkg/uuid/BUILD
+++ b/pkg/uuid/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_package()


### PR DESCRIPTION
Major change is that you now explicitly declare one `go_package` target per directory.

This also demonstrates the new features of `testdata` folder and resource embedding.